### PR TITLE
LC-322: adding capacity checker for token users

### DIFF
--- a/src/main/java/uk/gov/cshr/utils/ApplicationConstants.java
+++ b/src/main/java/uk/gov/cshr/utils/ApplicationConstants.java
@@ -1,9 +1,10 @@
 package uk.gov.cshr.utils;
 
 public class ApplicationConstants {
-
+    
     public static final String STATUS_ATTRIBUTE = "status";
 
     public static final String ENTER_TOKEN_ERROR_MESSAGE = "Incorrect organisation or token";
 
+    public static final String NO_SPACES_AVAILABLE_ERROR_MESSAGE = "No spaces available for this token. Please contact your line manager";
 }

--- a/src/test/java/uk/gov/cshr/controller/signup/SignupControllerTest.java
+++ b/src/test/java/uk/gov/cshr/controller/signup/SignupControllerTest.java
@@ -439,7 +439,7 @@ public class SignupControllerTest {
     }
 
     @Test
-    public void shouldRedirectToSignupIfInviteValid() throws Exception {
+    public void shouldRedirectToSignupIfInviteValidAndAgencyTokenHasCapacity() throws Exception {
         String code = "abc123";
         String organisation = "org";
         String token = "token123";
@@ -451,6 +451,8 @@ public class SignupControllerTest {
         invite.setAuthorisedInvite(true);
 
         AgencyToken agencyToken = new AgencyToken();
+        agencyToken.setCapacity(10);
+        agencyToken.setCapacityUsed(5);
         Optional<AgencyToken> optionalAgencyToken = Optional.of(agencyToken);
 
         when(inviteService.isInviteValid(code)).thenReturn(true);
@@ -468,7 +470,39 @@ public class SignupControllerTest {
                 .andExpect(redirectedUrl("/signup/" + code));
     }
 
-    @Test 
+    @Test
+    public void shouldRedirectToTokenWithErroIfInviteValidAndAgencyTokenDoesNotHaveCapacity() throws Exception {
+        String code = "abc123";
+        String organisation = "org";
+        String token = "token123";
+        String email = "test@example.com";
+        String domain = "example.com";
+
+        Invite invite = new Invite();
+        invite.setForEmail(email);
+        invite.setAuthorisedInvite(true);
+
+        AgencyToken agencyToken = new AgencyToken();
+        agencyToken.setCapacity(10);
+        agencyToken.setCapacityUsed(10);
+        Optional<AgencyToken> optionalAgencyToken = Optional.of(agencyToken);
+
+        when(inviteService.isInviteValid(code)).thenReturn(true);
+        when(inviteRepository.findByCode(code)).thenReturn(invite);
+        when(identityService.getDomainFromEmailAddress(email)).thenReturn(domain);
+        when(csrsService.getAgencyTokenForDomainTokenOrganisation(domain, token, organisation)).thenReturn(optionalAgencyToken);
+
+        mockMvc.perform(
+                post("/signup/enterToken/" + code)
+                        .with(CsrfRequestPostProcessor.csrf())
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                        .param("organisation", organisation)
+                        .param("token", token))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/signup/enterToken/" + code));
+    }
+
+    @Test
     public void shouldRedirectToEnterTokenWithErrorMessageIfNoTokensFound() throws Exception {
         String code = "abc123";
         String organisation = "org";


### PR DESCRIPTION
Hotfix to add a capacity checker for user signing up to an agency token. Application should prevent user from validating with an agency token if the token has no spaces available

In the signup flow for a token user, when they first try to validate their invite with a org and token, the app was not checking to if the token had any capacity. The only checks were done were at the post of the set your password screen. This felt like a little too late in the flow, as getting past the org + token screen would indicate that the validation has been successful. 

Removed some redundant comments. 

Fixed and added some tests.