### PR TITLE
LC 323 - signup updates for invited users

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ dependencies {
 
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.3'
 
+
     // https://github.com/alphagov/notifications-java-client
     compile('uk.gov.service.notify:notifications-java-client:3.9.1-RELEASE')
 
@@ -95,6 +96,8 @@ dependencies {
     testCompile 'org.powermock:powermock-module-junit4:1.7.4'
 
     testCompile 'org.mockito:mockito-core:2.8.47'
+
+    testCompile 'com.google.code.gson:gson:2.8.2'
 }
 
 compileJava.dependsOn(processResources)

--- a/src/main/java/uk/gov/cshr/config/ResourceServerConfiguration.java
+++ b/src/main/java/uk/gov/cshr/config/ResourceServerConfiguration.java
@@ -1,7 +1,5 @@
 package uk.gov.cshr.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,8 +14,6 @@ import uk.gov.cshr.service.security.WebSecurityExpressionHandler;
 public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {
 
     private static final String RESOURCE_ID = "identity_api";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceServerConfiguration.class);
 
     @Value("${server.port}")
     private int serverPort;
@@ -35,7 +31,7 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
         http
                 .anonymous().disable()
                 .requestMatchers()
-                .antMatchers("/oauth/resolve", "/oauth/revoke", "/api/**")
+                .antMatchers("/oauth/resolve", "/oauth/revoke", "/api/**", "/agency/**")
                 .and()
                 .authorizeRequests()
                 .requestMatchers(request -> serverPort != -1 && request.getLocalPort() != serverPort).denyAll()

--- a/src/main/java/uk/gov/cshr/controller/AgencyController.java
+++ b/src/main/java/uk/gov/cshr/controller/AgencyController.java
@@ -1,0 +1,35 @@
+package uk.gov.cshr.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.cshr.domain.AgencyTokenCapacityUsedDto;
+import uk.gov.cshr.service.AgencyTokenCapacityService;
+
+@RestController
+@Slf4j
+@RequestMapping("/agency")
+public class AgencyController {
+
+    private AgencyTokenCapacityService agencyTokenCapacityService;
+
+    public AgencyController(AgencyTokenCapacityService agencyTokenCapacityService) {
+        this.agencyTokenCapacityService = agencyTokenCapacityService;
+    }
+
+    @GetMapping("/{uid}")
+    public ResponseEntity<AgencyTokenCapacityUsedDto> getSpacesUsedForAgencyToken(@PathVariable(value = "uid") String uid) {
+        log.debug("Getting spaces used for agency token {}", uid);
+
+        try {
+            return ResponseEntity.ok(agencyTokenCapacityService.getSpacesUsedByAgencyToken(uid));
+        } catch (Exception e) {
+            log.error("Unexpected error calling getSpacesUsedForAgencyToken with uid = {}, {}", uid, e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/uk/gov/cshr/domain/AgencyToken.java
+++ b/src/main/java/uk/gov/cshr/domain/AgencyToken.java
@@ -4,7 +4,6 @@ import lombok.Data;
 
 @Data
 public class AgencyToken {
-    private String token;
+    private String uid;
     private int capacity;
-    private int capacityUsed;
 }

--- a/src/main/java/uk/gov/cshr/domain/AgencyTokenCapacityUsedDto.java
+++ b/src/main/java/uk/gov/cshr/domain/AgencyTokenCapacityUsedDto.java
@@ -1,0 +1,12 @@
+package uk.gov.cshr.domain;
+
+import lombok.Data;
+
+@Data
+public class AgencyTokenCapacityUsedDto {
+    private Long capacityUsed;
+
+    public AgencyTokenCapacityUsedDto(Long capacityUsed) {
+        this.capacityUsed = capacityUsed;
+    }
+}

--- a/src/main/java/uk/gov/cshr/domain/Identity.java
+++ b/src/main/java/uk/gov/cshr/domain/Identity.java
@@ -41,6 +41,9 @@ public class Identity implements Serializable {
     @Column
     private boolean emailRecentlyUpdated;
 
+    @Column
+    private String agencyTokenUid;
+
     public Identity() {
     }
 
@@ -54,6 +57,19 @@ public class Identity implements Serializable {
         this.lastLoggedIn = lastLoggedIn;
         this.deletionNotificationSent = deletionNotificationSent;
         this.emailRecentlyUpdated = emailRecentlyUpdated;
+    }
+
+    public Identity(String uid, String email, String password, boolean active, boolean locked, Set<Role> roles, Instant lastLoggedIn, boolean deletionNotificationSent, boolean emailRecentlyUpdated, String agencyTokenUid) {
+        this.uid = uid;
+        this.email = email;
+        this.password = password;
+        this.active = active;
+        this.roles = roles;
+        this.locked = locked;
+        this.lastLoggedIn = lastLoggedIn;
+        this.deletionNotificationSent = deletionNotificationSent;
+        this.emailRecentlyUpdated = emailRecentlyUpdated;
+        this.agencyTokenUid = agencyTokenUid;
     }
 
     public boolean isActive() {
@@ -86,6 +102,10 @@ public class Identity implements Serializable {
 
     public String getEmail() {
         return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 
     public Long getId() {
@@ -128,8 +148,12 @@ public class Identity implements Serializable {
         this.emailRecentlyUpdated = emailRecentlyUpdated;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
+    public String getAgencyTokenUid() {
+        return agencyTokenUid;
+    }
+
+    public void setAgencyTokenUid(String agencyTokenUid) {
+        this.agencyTokenUid = agencyTokenUid;
     }
 
     @Override

--- a/src/main/java/uk/gov/cshr/repository/IdentityRepository.java
+++ b/src/main/java/uk/gov/cshr/repository/IdentityRepository.java
@@ -21,6 +21,8 @@ public interface IdentityRepository extends JpaRepository<Identity, Long> {
         Optional<Identity> findFirstByUid(String uid);
 
         @Query("select new uk.gov.cshr.dto.IdentityDTO(i.email, i.uid) " +
-        "from Identity i")
+                "from Identity i")
         List<IdentityDTO> findAllNormalised();
-        }
+
+        Long countByAgencyTokenUid(String uid);
+}

--- a/src/main/java/uk/gov/cshr/repository/IdentityRepositoryMockImpl.java
+++ b/src/main/java/uk/gov/cshr/repository/IdentityRepositoryMockImpl.java
@@ -43,6 +43,11 @@ public class IdentityRepositoryMockImpl implements IdentityRepository {
     }
 
     @Override
+    public Long countByAgencyTokenUid(String name) {
+        return null;
+    }
+
+    @Override
     public List<Identity> findAll() {
         return null;
     }

--- a/src/main/java/uk/gov/cshr/service/AgencyTokenCapacityService.java
+++ b/src/main/java/uk/gov/cshr/service/AgencyTokenCapacityService.java
@@ -1,0 +1,34 @@
+package uk.gov.cshr.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.cshr.domain.AgencyToken;
+import uk.gov.cshr.domain.AgencyTokenCapacityUsedDto;
+import uk.gov.cshr.repository.IdentityRepository;
+
+@Slf4j
+@Service
+public class AgencyTokenCapacityService {
+
+    private IdentityRepository identityRepository;
+
+    public AgencyTokenCapacityService(IdentityRepository identityRepository) {
+        this.identityRepository = identityRepository;
+    }
+
+    public boolean hasSpaceAvailable(AgencyToken agencyToken) {
+        Long spacesUsed = identityRepository.countByAgencyTokenUid(agencyToken.getUid());
+
+        log.debug("Agency token uid={}, capacity={}, spaces used={}", agencyToken.getUid(), agencyToken.getCapacity(), spacesUsed);
+
+        return (agencyToken.getCapacity() - spacesUsed) > 0;
+    }
+
+    public AgencyTokenCapacityUsedDto getSpacesUsedByAgencyToken(String uid) {
+        return new AgencyTokenCapacityUsedDto(identityRepository.countByAgencyTokenUid(uid));
+    }
+
+    public Long getCountOfAgencyByUid(String uid) {
+        return identityRepository.countByAgencyTokenUid(uid);
+    }
+}

--- a/src/main/java/uk/gov/cshr/service/AgencyTokenService.java
+++ b/src/main/java/uk/gov/cshr/service/AgencyTokenService.java
@@ -1,8 +1,10 @@
 package uk.gov.cshr.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.cshr.service.security.IdentityService;
 
+@Slf4j
 @Service
 public class AgencyTokenService {
 
@@ -20,7 +22,7 @@ public class AgencyTokenService {
     }
 
     public boolean isDomainAnAgencyTokenDomain(String domain) {
-       return numAgencyTokens(domain) > 0 ? true : false;
+        return numAgencyTokens(domain) > 0 ? true : false;
     }
 
     private int numAgencyTokens(String domain) {

--- a/src/main/java/uk/gov/cshr/service/CsrsService.java
+++ b/src/main/java/uk/gov/cshr/service/CsrsService.java
@@ -3,7 +3,7 @@ package uk.gov.cshr.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -11,7 +11,10 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.cshr.domain.AgencyToken;
 import uk.gov.cshr.domain.OrganisationalUnitDto;
 import uk.gov.cshr.dto.AgencyTokenDTO;
-import uk.gov.cshr.exception.*;
+import uk.gov.cshr.exception.BadRequestException;
+import uk.gov.cshr.exception.NotEnoughSpaceAvailableException;
+import uk.gov.cshr.exception.ResourceNotFoundException;
+import uk.gov.cshr.exception.UnableToAllocateAgencyTokenException;
 
 import java.util.Optional;
 
@@ -40,6 +43,15 @@ public class CsrsService {
         this.organisationalUnitsFlatUrl = organisationalUnitsFlatUrl;
         this.updateSpacesAvailableUrl = updateSpacesAvailableUrl;
         this.getOrganisationUrl = getOrganisationUrl;
+    }
+
+    public Boolean isDomainInAgency(String domain) {
+        try {
+            return restTemplate.getForObject(String.format(agencyTokensByDomainFormat, domain), Boolean.class);
+        } catch (HttpClientErrorException e) {
+            log.error("An error occurred checking if domain in agency", e);
+            return false;
+        }
     }
 
     public AgencyToken[] getAgencyTokensForDomain(String domain) {

--- a/src/main/java/uk/gov/cshr/service/security/IdentityService.java
+++ b/src/main/java/uk/gov/cshr/service/security/IdentityService.java
@@ -13,13 +13,13 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.cshr.domain.AgencyToken;
-import uk.gov.cshr.domain.Identity;
-import uk.gov.cshr.domain.Invite;
-import uk.gov.cshr.domain.Role;
+import uk.gov.cshr.domain.*;
 import uk.gov.cshr.exception.IdentityNotFoundException;
+import uk.gov.cshr.exception.ResourceNotFoundException;
+import uk.gov.cshr.exception.UnableToAllocateAgencyTokenException;
 import uk.gov.cshr.repository.IdentityRepository;
 import uk.gov.cshr.repository.TokenRepository;
+import uk.gov.cshr.service.AgencyTokenCapacityService;
 import uk.gov.cshr.service.CsrsService;
 import uk.gov.cshr.service.InviteService;
 import uk.gov.cshr.service.NotifyService;
@@ -39,16 +39,15 @@ public class IdentityService implements UserDetailsService {
     private final String updatePasswordEmailTemplateId;
 
     private final IdentityRepository identityRepository;
-
-    private InviteService inviteService;
-
     private final PasswordEncoder passwordEncoder;
     private final TokenServices tokenServices;
     private final TokenRepository tokenRepository;
     private final NotifyService notifyService;
     private final CsrsService csrsService;
     private final SpringUserUtils springUserUtils;
+    private InviteService inviteService;
     private String[] whitelistedDomains;
+    private AgencyTokenCapacityService agencyTokenCapacityService;
 
     public IdentityService(@Value("${govNotify.template.passwordUpdate}") String updatePasswordEmailTemplateId,
                            IdentityRepository identityRepository,
@@ -58,7 +57,7 @@ public class IdentityService implements UserDetailsService {
                            @Qualifier("notifyServiceImpl") NotifyService notifyService,
                            CsrsService csrsService,
                            SpringUserUtils springUserUtils,
-                           @Value("${invite.whitelist.domains}") String[] whitelistedDomains) {
+                           @Value("${invite.whitelist.domains}") String[] whitelistedDomains, AgencyTokenCapacityService agencyTokenCapacityService) {
         this.updatePasswordEmailTemplateId = updatePasswordEmailTemplateId;
         this.identityRepository = identityRepository;
         this.passwordEncoder = passwordEncoder;
@@ -68,6 +67,7 @@ public class IdentityService implements UserDetailsService {
         this.csrsService = csrsService;
         this.springUserUtils = springUserUtils;
         this.whitelistedDomains = whitelistedDomains;
+        this.agencyTokenCapacityService = agencyTokenCapacityService;
     }
 
     @Autowired
@@ -89,14 +89,43 @@ public class IdentityService implements UserDetailsService {
         return identityRepository.existsByEmail(email);
     }
 
-    public void createIdentityFromInviteCode(String code, String password) {
+    @Transactional(noRollbackFor = UnableToAllocateAgencyTokenException.class)
+    public void createIdentityFromInviteCode(String code, String password, TokenRequest tokenRequest) {
         Invite invite = inviteService.findByCode(code);
 
         Set<Role> newRoles = new HashSet<>(invite.getForRoles());
-        Identity identity = new Identity(UUID.randomUUID().toString(), invite.getForEmail(), passwordEncoder.encode(password), true, false, newRoles, Instant.now(), false, false);
+
+        String agencyTokenUid = null;
+        if (requestHasTokenData(tokenRequest)) {
+            Optional<AgencyToken> agencyTokenForDomainTokenOrganisation = csrsService.getAgencyTokenForDomainTokenOrganisation(tokenRequest.getDomain(), tokenRequest.getToken(), tokenRequest.getOrg());
+
+            agencyTokenUid = agencyTokenForDomainTokenOrganisation
+                    .map(agencyToken -> {
+                        if (agencyTokenCapacityService.hasSpaceAvailable(agencyToken)) {
+                            return agencyToken.getUid();
+                        } else {
+                            throw new UnableToAllocateAgencyTokenException("Agency token uid " + agencyToken.getUid() + " has no spaces available. Identity not created");
+                        }
+                    })
+                    .orElseThrow(ResourceNotFoundException::new);
+
+            log.info("Identity request has agency uid = {}", agencyTokenUid);
+        }
+
+        Identity identity = new Identity(UUID.randomUUID().toString(),
+                invite.getForEmail(),
+                passwordEncoder.encode(password),
+                true,
+                false,
+                newRoles,
+                Instant.now(),
+                false,
+                false,
+                agencyTokenUid);
+
         identityRepository.save(identity);
 
-        LOGGER.info("New identity {} successfully created", identity.getEmail());
+        LOGGER.debug("New identity email = {} successfully created", identity.getEmail());
     }
 
     public void updatePassword(Identity identity, String password) {
@@ -194,4 +223,13 @@ public class IdentityService implements UserDetailsService {
         return false;
     }
 
+    private boolean requestHasTokenData(TokenRequest tokenRequest) {
+        return hasData(tokenRequest.getDomain())
+                && hasData(tokenRequest.getToken())
+                && hasData(tokenRequest.getOrg());
+    }
+
+    private boolean hasData(String s) {
+        return s != null && s.length() > 0;
+    }
 }

--- a/src/main/java/uk/gov/cshr/utils/ApplicationConstants.java
+++ b/src/main/java/uk/gov/cshr/utils/ApplicationConstants.java
@@ -7,4 +7,9 @@ public class ApplicationConstants {
     public static final String ENTER_TOKEN_ERROR_MESSAGE = "Incorrect organisation or token";
 
     public static final String NO_SPACES_AVAILABLE_ERROR_MESSAGE = "No spaces available for this token. Please contact your line manager";
+
+    public static final String SIGNUP_RESOURCE_NOT_FOUND_ERROR_MESSAGE = "Cannot complete signup as there are there was problem with the token provided. Please contact your line manager";
+
+    public static final String SIGNUP_NO_SPACES_AVAILABLE_ERROR_MESSAGE = "Cannot complete signup as there are no spaces available for this token. Please contact your line manager";
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+    show-sql: false
 
 
 server:
@@ -46,7 +47,7 @@ invite:
   url: ${INVITE_SIGNUP_URL:http://localhost:8080/signup/%s}
   validityInSeconds: ${INVITE_VALIDITY:259200}
   whitelist:
-    domains: ${WHITELISTED_DOMAINS:kainos.com, domain.com}
+    domains: ${WHITELISTED_DOMAINS:example.com, domain.com, gov.uk}
 
 reset:
   url: ${RESET_URL:http://localhost:8080/reset/%s}

--- a/src/main/resources/db/migration/h2/V1.1__data.sql
+++ b/src/main/resources/db/migration/h2/V1.1__data.sql
@@ -95,3 +95,5 @@ CREATE TABLE `oauth_code` (
 );
 
 ALTER TABLE `invite` ADD COLUMN `is_authorised_invite` bit(1) DEFAULT TRUE;
+
+ALTER TABLE `identity` ADD COLUMN `agency_token_uid` char(36);

--- a/src/main/resources/db/migration/mysql/V1.8.1__adding-agency-uid-to-identity.sql
+++ b/src/main/resources/db/migration/mysql/V1.8.1__adding-agency-uid-to-identity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `identity` ADD COLUMN `agency_token_uid` char(36);

--- a/src/main/resources/templates/enterToken.html
+++ b/src/main/resources/templates/enterToken.html
@@ -7,7 +7,7 @@
         <div class="container">
             <div class="grid-row">
                 <div class="column-two-thirds">
-                    <a href="/" class="link-back">Back</a>
+                    <a href="/login" class="link-back">Back</a>
                     <div th:if="${status}" class="error-summary" role="alert"  aria-labelledby="error-summary-heading-example-1" tabindex="-1">
                         <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">There was
                             a problem</h2>

--- a/src/main/resources/templates/requestInvite.html
+++ b/src/main/resources/templates/requestInvite.html
@@ -5,7 +5,7 @@
         <div class="container">
             <div class="grid-row">
                 <div class="column-two-thirds">
-                    <a href="/" class="link-back">Back</a>
+                    <a href="/login" class="link-back">Back</a>
                     <div th:if="${status}" class="error-summary" role="alert"  aria-labelledby="error-summary-heading-example-1" tabindex="-1">
                         <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">
                             There was a problem inviting this email address

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -5,11 +5,21 @@
         <div class="container">
             <div class="grid-row">
                 <div class="column-two-thirds">
+                    <a href="/login" class="link-back">Back</a>
                     <div th:if="${#fields.hasErrors('${signupForm.*}')}" class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
                         <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">There was a problem with your password</h2>
                         <ul class="error-summary-list">
                             <li th:if="${#fields.hasErrors('${signupForm.password}')}"><a href="#password" th:errors="${signupForm.password}">Password is invalid</a></li>
                             <li th:if="${#fields.hasErrors('${signupForm.*}')}"><a href="#passwordConfirm" th:errors="${signupForm}">Passwords do not match</a></li>
+                        </ul>
+                    </div>
+
+                    <div th:if="${status}" class="error-summary" role="alert"
+                         aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+                        <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-2">There was
+                            a problem</h2>
+                        <ul class="error-summary-list">
+                            <li><a href="#token" th:text="${status}">status ...</a></li>
                         </ul>
                     </div>
 

--- a/src/test/java/uk/gov/cshr/controller/AgencyControllerTest.java
+++ b/src/test/java/uk/gov/cshr/controller/AgencyControllerTest.java
@@ -1,0 +1,58 @@
+package uk.gov.cshr.controller;
+
+import com.google.gson.Gson;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import uk.gov.cshr.domain.AgencyTokenCapacityUsedDto;
+import uk.gov.cshr.service.AgencyTokenCapacityService;
+import uk.gov.cshr.utils.MockMVCFilterOverrider;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest({AgencyController.class})
+@WithMockUser(username = "user")
+public class AgencyControllerTest {
+
+    private static final String UID = "UID";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Gson gson;
+
+    @MockBean
+    private AgencyTokenCapacityService agencyTokenCapacityService;
+
+    @Before
+    public void overridePatternMappingFilterProxyFilter() throws IllegalAccessException {
+        MockMVCFilterOverrider.overrideFilterOf(mockMvc, "PatternMappingFilterProxy");
+    }
+
+    @Test
+    public void getSpacesUsedForAgencyToken() throws Exception {
+        AgencyTokenCapacityUsedDto agencyTokenCapacityUsedDto = new AgencyTokenCapacityUsedDto(100L);
+
+        when(agencyTokenCapacityService.getSpacesUsedByAgencyToken(UID)).thenReturn(agencyTokenCapacityUsedDto);
+
+        mockMvc.perform(
+                MockMvcRequestBuilders.get(String.format("/agency/%s", UID))
+                        .accept(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().json(gson.toJson(agencyTokenCapacityUsedDto)));
+    }
+}

--- a/src/test/java/uk/gov/cshr/service/AgencyTokenCapacityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/AgencyTokenCapacityServiceTest.java
@@ -1,0 +1,87 @@
+package uk.gov.cshr.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.cshr.domain.AgencyToken;
+import uk.gov.cshr.domain.AgencyTokenCapacityUsedDto;
+import uk.gov.cshr.repository.IdentityRepository;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AgencyTokenCapacityServiceTest {
+
+    private static final String UID = "UID";
+
+    @Mock
+    private IdentityRepository identityRepository;
+
+    @InjectMocks
+    private AgencyTokenCapacityService agencyTokenCapacityService;
+
+    @Test
+    public void shouldReturnTrueIfManySpacesAvailable() {
+        AgencyToken agencyToken = new AgencyToken();
+        agencyToken.setUid(UID);
+        agencyToken.setCapacity(100);
+
+        when(identityRepository.countByAgencyTokenUid(UID)).thenReturn(1L);
+
+        assertTrue(agencyTokenCapacityService.hasSpaceAvailable(agencyToken));
+    }
+
+    @Test
+    public void shouldReturnTrueIfOneSpaceAvailable() {
+        AgencyToken agencyToken = new AgencyToken();
+        agencyToken.setUid(UID);
+        agencyToken.setCapacity(100);
+
+        when(identityRepository.countByAgencyTokenUid(UID)).thenReturn(99L);
+
+        assertTrue(agencyTokenCapacityService.hasSpaceAvailable(agencyToken));
+    }
+
+    @Test
+    public void shouldReturnFalseIfNoSpaceAvailable() {
+        AgencyToken agencyToken = new AgencyToken();
+        agencyToken.setUid(UID);
+        agencyToken.setCapacity(100);
+
+        when(identityRepository.countByAgencyTokenUid(UID)).thenReturn(100L);
+
+        assertFalse(agencyTokenCapacityService.hasSpaceAvailable(agencyToken));
+    }
+
+    @Test
+    public void shouldReturnFalseIfNoSpaceAvailableWhereCapacityReduced() {
+        AgencyToken agencyToken = new AgencyToken();
+        agencyToken.setUid(UID);
+        agencyToken.setCapacity(100);
+
+        when(identityRepository.countByAgencyTokenUid(UID)).thenReturn(101L);
+
+        assertFalse(agencyTokenCapacityService.hasSpaceAvailable(agencyToken));
+    }
+
+    @Test
+    public void shouldReturnSpacesUsedByAgencyToken() {
+        AgencyTokenCapacityUsedDto expected = new AgencyTokenCapacityUsedDto(new Long(100));
+
+        when(identityRepository.countByAgencyTokenUid(UID)).thenReturn(100L);
+
+        assertEquals(expected, agencyTokenCapacityService.getSpacesUsedByAgencyToken(UID));
+    }
+
+    @Test
+    public void shouldReturnCountByAgencyToken() {
+        when(identityRepository.countByAgencyTokenUid(UID)).thenReturn(100L);
+
+        Long countOfAgencyByUid = agencyTokenCapacityService.getCountOfAgencyByUid(UID);
+
+        assertEquals(new Long(100), countOfAgencyByUid);
+    }
+}

--- a/src/test/java/uk/gov/cshr/service/AgencyTokenServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/AgencyTokenServiceTest.java
@@ -8,12 +8,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.cshr.domain.AgencyToken;
 import uk.gov.cshr.service.security.IdentityService;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AgencyTokenServiceTest {
+    private static final String DOMAIN = "someone@kainos.com";
 
     @Mock
     private IdentityService identityService;
@@ -22,61 +24,46 @@ public class AgencyTokenServiceTest {
     private CsrsService csrsService;
 
     @InjectMocks
-    private AgencyTokenService classUnderTest;
-
-    private static final String DOMAIN = "someone@kainos.com";
+    private AgencyTokenService agencyTokenService;
 
     @Test
     public void givenAWhitelistedDomain_whenIsDomainWhiteListed_thenShouldReturnTrue() {
-        // given
         when(identityService.isWhitelistedDomain(anyString())).thenReturn(true);
 
-        // when
-        boolean actual = classUnderTest.isDomainWhiteListed(DOMAIN);
+        boolean actual = agencyTokenService.isDomainWhiteListed(DOMAIN);
 
-        // then
         assertTrue(actual);
     }
 
     @Test
     public void givenANonWhitelistedDomain_whenIsDomainWhiteListed_thenShouldReturnFalse() {
-        // given
         when(identityService.isWhitelistedDomain(anyString())).thenReturn(false);
 
-        // when
-        boolean actual = classUnderTest.isDomainWhiteListed(DOMAIN);
+        boolean actual = agencyTokenService.isDomainWhiteListed(DOMAIN);
 
-        // then
         assertFalse(actual);
     }
 
     @Test
     public void givenNonWhitelistedDomainWithAgencyTokenDomains_whenIsDomainAnAgencyTokenDomain_thenShouldReturnTrue() {
-        // given
         AgencyToken [] agencyTokens = new AgencyToken[3];
         agencyTokens[0] = new AgencyToken();
         agencyTokens[1] = new AgencyToken();
         agencyTokens[2] = new AgencyToken();
         when(csrsService.getAgencyTokensForDomain(anyString())).thenReturn(agencyTokens);
 
-        // when
-        boolean actual = classUnderTest.isDomainAnAgencyTokenDomain(DOMAIN);
+        boolean actual = agencyTokenService.isDomainAnAgencyTokenDomain(DOMAIN);
 
-        // then
         assertTrue(actual);
     }
 
     @Test
     public void givenNonWhitelistedDomainWithNoAgencyTokenDomains_whenIsDomainAnAgencyTokenDomain_thenShouldReturnFalse() {
-        // given
         AgencyToken [] agencyTokens = new AgencyToken[0];
         when(csrsService.getAgencyTokensForDomain(anyString())).thenReturn(agencyTokens);
 
-        // when
-        boolean actual = classUnderTest.isDomainAnAgencyTokenDomain(DOMAIN);
+        boolean actual = agencyTokenService.isDomainAnAgencyTokenDomain(DOMAIN);
 
-        // then
         assertFalse(actual);
     }
-
 }

--- a/src/test/java/uk/gov/cshr/service/CsrsServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/CsrsServiceTest.java
@@ -17,7 +17,10 @@ import org.springframework.web.client.RestTemplate;
 import uk.gov.cshr.domain.AgencyToken;
 import uk.gov.cshr.domain.OrganisationalUnitDto;
 import uk.gov.cshr.dto.AgencyTokenDTO;
-import uk.gov.cshr.exception.*;
+import uk.gov.cshr.exception.BadRequestException;
+import uk.gov.cshr.exception.NotEnoughSpaceAvailableException;
+import uk.gov.cshr.exception.ResourceNotFoundException;
+import uk.gov.cshr.exception.UnableToAllocateAgencyTokenException;
 
 import java.util.Optional;
 
@@ -69,6 +72,28 @@ public class CsrsServiceTest {
     }
 
     @Test
+    public void shouldReturnTrueIfDomainInAgency() {
+        String domain = "example.com";
+
+        Boolean expectedBoolean = true;
+
+        when(restTemplate.getForObject(String.format(agencyTokensByDomainFormat, domain), Boolean.class)).thenReturn(expectedBoolean);
+
+        assertEquals(expectedBoolean, csrsService.isDomainInAgency(domain));
+    }
+
+    @Test
+    public void shouldReturnFalseIfDomainInAgency() {
+        String domain = "example.com";
+
+        Boolean expectedBoolean = false;
+
+        when(restTemplate.getForObject(String.format(agencyTokensByDomainFormat, domain), Boolean.class)).thenReturn(expectedBoolean);
+
+        assertEquals(expectedBoolean, csrsService.isDomainInAgency(domain));
+    }
+
+    @Test
     public void shouldReturnAgencyTokenForDomainTokenOrganisation() {
         AgencyToken agencyToken = new AgencyToken();
         String domain = "example.com";
@@ -102,23 +127,6 @@ public class CsrsServiceTest {
         when(restTemplate.getForObject(organisationalUnitsFlatUrl, OrganisationalUnitDto[].class)).thenReturn(organisationalUnitDtoArray);
 
         assertArrayEquals(organisationalUnitDtoArray, csrsService.getOrganisationalUnitsFormatted());
-    }
-
-    @Test
-    public void givenAgencyTokenDomainAndOrganisation_whenGetAgencyTokenForDomainAndOrganisation_thenShouldReturnAgencyToken() {
-        // given
-        AgencyToken agencyToken = buildAgencyToken();
-        String domain = "example.com";
-        String code = "code";
-        when(restTemplate.getForObject(String.format(agencyTokensByDomainAndOrganisationFormat, domain, code), AgencyToken.class)).thenReturn(agencyToken);
-
-        // when
-        Optional<AgencyToken> actual = csrsService.getAgencyTokenForDomainAndOrganisation(domain, code);
-
-        // then
-        assertThat(actual.get().getToken(), equalTo(agencyToken.getToken()));
-        assertThat(actual.get().getCapacity(), equalTo(100));
-        assertThat(actual.get().getCapacityUsed(), equalTo(11));
     }
 
     @Test
@@ -279,9 +287,6 @@ public class CsrsServiceTest {
 
     private AgencyToken buildAgencyToken() {
         AgencyToken at = new AgencyToken();
-        at.setToken("token123");
-        at.setCapacity(100);
-        at.setCapacityUsed(11);
         return at;
     }
 

--- a/src/test/java/uk/gov/cshr/service/EmailUpdateServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/EmailUpdateServiceTest.java
@@ -272,9 +272,6 @@ public class EmailUpdateServiceTest {
 
     private AgencyToken buildAgencyToken() {
         AgencyToken at = new AgencyToken();
-        at.setToken("token123");
-        at.setCapacity(100);
-        at.setCapacityUsed(11);
         return at;
     }
 }


### PR DESCRIPTION
Updating the signup flows to handle 'invited' users. 

- new agency_token_uid attribute so we can easily associate an agency token to a user
- new agencyToken controller and service classes to allow APIs to get count of agency tokens in use
- refactoring of SignupController to use new agencyToken and CSRS endpoints, exception handling and extracting literals into constants
- unit tests