### PR TITLE
Changing the behaviour of logout to redirect users to login if no returnTo param is set

### DIFF
--- a/src/main/java/uk/gov/cshr/config/UserSecurityConfig.java
+++ b/src/main/java/uk/gov/cshr/config/UserSecurityConfig.java
@@ -41,7 +41,7 @@ public class UserSecurityConfig extends WebSecurityConfigurerAdapter {
                 .logoutSuccessHandler((request, response, authentication) -> {
                     String redirectUrl = request.getParameter("returnTo");
                     if (redirectUrl == null) {
-                        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                        response.sendRedirect("/login");
                     } else {
                         response.sendRedirect(redirectUrl);
                     }


### PR DESCRIPTION
This will fix the whitelabel error caused by getting a 400 BAD REQUEST error when a user navigates directly to the /home endpoint (e.g. via a bookmark) when their session is not active.

Normally the app redirects to {identity-service-url}/logout but without a returnTo param to redirect the user the logout page throws an error. This change simply redirects the user to /login instead of throwing an error.

I'd also like to cherry-pick this change into the f2f release branch if we can get this build validated in a deployed environment. PR for that is TBC.