### PR TITLE
hotfix: removing set active to false on agency token delete

### DIFF
--- a/src/main/java/uk/gov/cshr/repository/IdentityRepository.java
+++ b/src/main/java/uk/gov/cshr/repository/IdentityRepository.java
@@ -32,6 +32,6 @@ public interface IdentityRepository extends JpaRepository<Identity, Long> {
 
         @Transactional
         @Modifying(flushAutomatically = true, clearAutomatically = true)
-        @Query("UPDATE Identity SET agencyTokenUid = null, active = false WHERE agencyTokenUid IS NOT NULL AND agencyTokenUid = :agencyTokenUid")
+        @Query("UPDATE Identity SET agencyTokenUid = null WHERE agencyTokenUid IS NOT NULL AND agencyTokenUid = :agencyTokenUid")
         void removeAgencyToken(String agencyTokenUid);
 }

--- a/src/test/java/uk/gov/cshr/repository/IdentityRepositoryTest.java
+++ b/src/test/java/uk/gov/cshr/repository/IdentityRepositoryTest.java
@@ -53,7 +53,7 @@ public class IdentityRepositoryTest {
         Identity postUpdateOtherAgencyTokenIdentity = identityRepository.getOne(otherAgencyTokenIdentity.getId());
         Identity postUpdateOtherNonAgencyIdentity = identityRepository.getOne(otherNonAgencyIdentity.getId());
 
-        assertFalse(updatedIdentity.isActive());
+        assertTrue(updatedIdentity.isActive());
         assertNull(updatedIdentity.getAgencyTokenUid());
 
         assertEquals(otherAgencyTokenIdentity.toString(), postUpdateOtherAgencyTokenIdentity.toString());
@@ -82,10 +82,10 @@ public class IdentityRepositoryTest {
         Identity postUpdateOtherAgencyTokenIdentity = identityRepository.getOne(otherAgencyTokenIdentity.getId());
         Identity postUpdateOtherNonAgencyIdentity = identityRepository.getOne(otherNonAgencyIdentity.getId());
 
-        assertFalse(updatedIdentityOne.isActive());
+        assertTrue(updatedIdentityOne.isActive());
         assertNull(updatedIdentityOne.getAgencyTokenUid());
 
-        assertFalse(updatedIdentityTwo.isActive());
+        assertTrue(updatedIdentityTwo.isActive());
         assertNull(updatedIdentityTwo.getAgencyTokenUid());
 
         assertEquals(otherAgencyTokenIdentity.toString(), postUpdateOtherAgencyTokenIdentity.toString());


### PR DESCRIPTION
No longer need to set Identity active = false when an agency token is deleted. Updating repository update to reflect this. 

Updating respective unit tests.