### PR TITLE
hotfix - reorder agency whitelist checks

### DIFF
--- a/src/main/java/uk/gov/cshr/controller/account/email/ChangeEmailController.java
+++ b/src/main/java/uk/gov/cshr/controller/account/email/ChangeEmailController.java
@@ -107,8 +107,11 @@ public class ChangeEmailController {
 
         log.debug("Attempting update email verification with domain: {}", newDomain);
 
-
-        if (isWhitelisted(newDomain)) {
+        if (isAgencyDomain(newDomain)) {
+            log.debug("New email is agency: oldEmail = {}, newEmail = {}", identity.getEmail(), emailUpdate.getEmail());
+            redirectAttributes.addFlashAttribute(EMAIL_ATTRIBUTE, emailUpdate.getEmail());
+            return REDIRECT_ACCOUNT_ENTER_TOKEN + code;
+        } else if (isWhitelisted(newDomain)) {
             log.debug("New email is whitelisted: oldEmail = {}, newEmail = {}", identity.getEmail(), emailUpdate.getEmail());
             try {
                 emailUpdateService.updateEmailAddress(emailUpdate);
@@ -123,10 +126,6 @@ public class ChangeEmailController {
                 log.error("Unable to update email: {} {}", code, identity);
                 return REDIRECT_LOGIN;
             }
-        } else if (isNotWhitelistedAndIsAgency(newDomain)) {
-            log.debug("New email is agency: oldEmail = {}, newEmail = {}", identity.getEmail(), emailUpdate.getEmail());
-            redirectAttributes.addFlashAttribute(EMAIL_ATTRIBUTE, emailUpdate.getEmail());
-            return REDIRECT_ACCOUNT_ENTER_TOKEN + code;
         } else {
             log.error("User trying to verify change email where new email is not whitelisted or agency: oldEmail = {}, newEmail = {}", identity.getEmail(), emailUpdate.getEmail());
             redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.CHANGE_EMAIL_ERROR_MESSAGE);
@@ -151,7 +150,7 @@ public class ChangeEmailController {
         return identityService.isWhitelistedDomain(newDomain);
     }
 
-    private boolean isNotWhitelistedAndIsAgency(String newDomain) {
-        return !identityService.isWhitelistedDomain(newDomain) && agencyTokenService.isDomainInAgencyToken(newDomain);
+    private boolean isAgencyDomain(String newDomain) {
+        return agencyTokenService.isDomainInAgencyToken(newDomain);
     }
 }

--- a/src/main/java/uk/gov/cshr/controller/signup/SignupController.java
+++ b/src/main/java/uk/gov/cshr/controller/signup/SignupController.java
@@ -108,14 +108,14 @@ public class SignupController {
 
         final String domain = identityService.getDomainFromEmailAddress(email);
 
-        if (identityService.isWhitelistedDomain(domain)) {
-            log.debug("Sending invite to whitelisted user {}", email);
-            inviteService.sendSelfSignupInvite(email, true);
+        if (csrsService.isDomainInAgency(domain)) {
+            log.debug("Sending invite to agency user {}", email);
+            inviteService.sendSelfSignupInvite(email, false);
             return INVITE_SENT_TEMPLATE;
         } else {
-            if (csrsService.isDomainInAgency(domain)) {
-                log.debug("Sending invite to agency user {}", email);
-                inviteService.sendSelfSignupInvite(email, false);
+            if (identityService.isWhitelistedDomain(domain)) {
+                log.debug("Sending invite to whitelisted user {}", email);
+                inviteService.sendSelfSignupInvite(email, true);
                 return INVITE_SENT_TEMPLATE;
             } else {
                 log.debug("The domain of user {} is neither Whitelisted nor part of an Agency token", email);

--- a/src/test/java/uk/gov/cshr/controller/account/email/ChangeEmailControllerTest.java
+++ b/src/test/java/uk/gov/cshr/controller/account/email/ChangeEmailControllerTest.java
@@ -379,19 +379,17 @@ public class ChangeEmailControllerTest {
 
         IdentityDetails identityDetails = (IdentityDetails) authentication.getPrincipal();
         Identity identity = identityDetails.getIdentity();
-        String expectedUIDToBeUpdated = identity.getUid();
-        String expectedEmailToBeUpdated = identity.getEmail();
 
         EmailUpdate emailUpdate = new EmailUpdate();
         emailUpdate.setCode(VERIFY_CODE);
         emailUpdate.setEmail(identity.getEmail());
 
+        when(agencyTokenService.isDomainInAgencyToken(DOMAIN)).thenReturn(false);
         when(emailUpdateService.existsByCode(VERIFY_CODE)).thenReturn(true);
         when(emailUpdateService.getEmailUpdateByCode(VERIFY_CODE)).thenReturn(emailUpdate);
         when(identityService.getDomainFromEmailAddress(identity.getEmail())).thenReturn(DOMAIN);
-
         when(identityService.isWhitelistedDomain(DOMAIN)).thenReturn(true);
-        when(agencyTokenService.isDomainInAgencyToken(DOMAIN)).thenReturn(true);
+        when(agencyTokenService.isDomainInAgencyToken(DOMAIN)).thenReturn(false);
 
         doThrow(new ResourceNotFoundException()).when(emailUpdateService).updateEmailAddress(any(EmailUpdate.class));
 
@@ -426,7 +424,7 @@ public class ChangeEmailControllerTest {
         when(identityService.getDomainFromEmailAddress(identity.getEmail())).thenReturn(DOMAIN);
 
         when(identityService.isWhitelistedDomain(DOMAIN)).thenReturn(true);
-        when(agencyTokenService.isDomainInAgencyToken(DOMAIN)).thenReturn(true);
+        when(agencyTokenService.isDomainInAgencyToken(DOMAIN)).thenReturn(false);
 
         doThrow(new RuntimeException()).when(emailUpdateService).updateEmailAddress(any(EmailUpdate.class));
 


### PR DESCRIPTION
Reordering if statement conditions to check if a user is agency ahead of checking if whitelisted.