### PR TITLE
Adding status index to identity DB token table to improve initial token fetch and duplicate remediation job queries

### DIFF
--- a/src/main/resources/db/migration/mysql/V1.9.3__token-table-status-index.sql
+++ b/src/main/resources/db/migration/mysql/V1.9.3__token-table-status-index.sql
@@ -1,0 +1,1 @@
+create index token_status_idx on `token` (status);


### PR DESCRIPTION
To assist duplicate remediation job and prevent timing out on larger table sizes when querying by status.