### PR TITLE
Update Crown Copyright links

### DIFF
--- a/src/main/resources/templates/fragments/user-footer.html
+++ b/src/main/resources/templates/fragments/user-footer.html
@@ -34,7 +34,7 @@
                 </div>
             </div>
             <div class="copyright">
-                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">
+                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
                     © Crown copyright
                 </a>
             </div>

--- a/src/main/resources/templates/maintenance.html
+++ b/src/main/resources/templates/maintenance.html
@@ -77,7 +77,7 @@
                 </div>
             </div>
             <div class="copyright">
-                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">
+                <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
                     © Crown copyright
                 </a>
             </div>


### PR DESCRIPTION
This change updates the link for the "Crown copyright" at the footer to the correct address. Mainly applies to the sign in and sign up pages.