### PR TITLE
Update MySQL Connector / JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM amazoncorretto:8-alpine
 
 ENV SPRING_PROFILES_ACTIVE production
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
 
     // https://mvnrepository.com/artifact/mysql/mysql-connector-java
-    compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.8-dmr'
+    compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.13'
 
     compile group: 'org.flywaydb', name: 'flyway-core', version: '5.0.7'
 


### PR DESCRIPTION
Part of the fixing the missing patches is to upgrade MySQL to version 8.0. To accommodate for this, the MySQL Connector needs to be updated to version 8.0.13

This change also updates the JDK to AmazonCoretto 8.0