### PR TITLE
LC-1866: Fix local development issue

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,7 +90,6 @@ registry:
   agencyTokensByDomainFormat: "${registry.serviceUrl}/agencyTokens?domain=%s"
   agencyTokensByDomainAndOrganisationFormat: "${registry.serviceUrl}/agencyTokens?domain=%s&code=%s"
   organisationalUnitsFlatUrl: "${registry.serviceUrl}/organisationalUnits/flat"
----
 identity:
   identityBaseUrl: ${IDENTITY_BASE_URL:http://identity:8080}
 
@@ -100,6 +99,8 @@ reactivation:
 
 textEncryption:
   encryptionKey: ${ENCRYPTION_KEY:0123456789abcdef0123456789abcdef}
+
+---
 
 spring:
   profiles: test, production

--- a/src/main/resources/db/migration/h2/V1.3__add-client-for-management.sql
+++ b/src/main/resources/db/migration/h2/V1.3__add-client-for-management.sql
@@ -1,0 +1,2 @@
+INSERT INTO `client` (active, uid, password, redirect_uri)
+VALUES (true, '89e1b5f4-01e6-470a-b2dc-78969140052a', '$2a$10$AbxhLGtIx7yv8jhF0BePiOxnb1mlHHq/Ge4R3PxCL2wIsoEov1VaS', 'http://develop.learn.civilservice.gov.uk:3005/authenticate');

--- a/src/main/resources/db/migration/mysql/V1.9.5__add-client-for-management.sql
+++ b/src/main/resources/db/migration/mysql/V1.9.5__add-client-for-management.sql
@@ -1,0 +1,2 @@
+INSERT INTO `client` (active, uid, password, redirect_uri)
+VALUES (true, '89e1b5f4-01e6-470a-b2dc-78969140052a', '$2a$10$AbxhLGtIx7yv8jhF0BePiOxnb1mlHHq/Ge4R3PxCL2wIsoEov1VaS', 'http://develop.learn.civilservice.gov.uk:3005/authenticate');


### PR DESCRIPTION
This change:
* moves the `---` in `application.yml` to fix an issue in local development where the value of `encryptionKey` isn't being passed on the app.
* Add a new client `http://develop.learn.civilservice.gov.uk:3005/authenticate` to the local database