### PR TITLE
LC-2762: Optimise MySQL connection strings

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -114,7 +114,7 @@ spring:
     cache: true
     check-template: true
   datasource:
-    url: ${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=true}
+    url: ${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=false}
     username: ${DATASOURCE_USERNAME:username}
     password: ${DATASOURCE_PASSWORD:password}
     platform: mysql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,7 +104,7 @@ textEncryption:
 ---
 
 database:
-  host: ${DATABASE_HOST:localhost}
+  host: ${DATABASE_HOST:jdbc:mysql://localhost:3306}
   name: ${DATABASE_NAME:identity}
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,6 +106,7 @@ textEncryption:
 database:
   host: ${DATABASE_HOST:jdbc:mysql://localhost:3306}
   name: ${DATABASE_NAME:identity}
+  use-ssl: ${DATABASE_USESSL:false}
 
 spring:
   profiles: test, production
@@ -113,7 +114,7 @@ spring:
     cache: true
     check-template: true
   datasource:
-    url: ${DATASOURCE_URL:${database.host}/${database.name}}
+    url: ${DATASOURCE_URL:${database.host}/${database.name}?useSSL=${database.use-ssl}&requireSSL=true}
     username: ${DATASOURCE_USERNAME:username}
     password: ${DATASOURCE_PASSWORD:password}
     platform: mysql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,13 +103,19 @@ textEncryption:
 
 ---
 
+database:
+  host: ${DATABASE_HOST:localhost}
+  name: ${DATABASE_NAME:identity}
+
 spring:
   profiles: test, production
   thymeleaf:
     cache: true
     check-template: true
   datasource:
-    url: ${DATASOURCE:jdbc:mysql://localhost:3306/identity?user=root&password=password&useSSL=false}
+    url: ${DATASOURCE_URL:${database.host}/${database.name}}
+    username: ${DATASOURCE_USERNAME:username}
+    password: ${DATASOURCE_PASSWORD:password}
     platform: mysql
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:


### PR DESCRIPTION
This change breaks up the connection strings into its individual components: host, database name, username, password and Use SSL. These environment variables are being introduced:

* `DATABASE_HOST`
* `DATABASE_NAME`
* `DATASOURCE_USERNAME`
* `DATASOURCE_PASSWORD`
* `DATABASE_USESSL`

The `spring.datasource.url` is then formed out of the above components.

This also removes the need for the `DATASOURCE` environment variable